### PR TITLE
VPC Gateway Endpoint for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This module creates the following resources:
 * Elastic IP for NAT Gateway (Optional)
 * Network ACL (Optional)
 * Transit Gateway attachment to the VPC (Optional)
+* VPC Gateway for S3 (Optional)
 
 ## Usage
 
@@ -201,6 +202,27 @@ For the transit gateway attachment to be successful:
 3. In the account with the transit gateway: wait until the shared principal status for the "child" account is "associated" (otherwise step 4. will fail)
 4. In the "child" account: Run and apply the terraform code referencing this module.
 5. In the account with the transit gateway: The request to attach the transit gateway to the VPC from the "child" account needs to be accepted within the transit gateway resource (unless auto accept is activated).
+
+### VPC Gateway for S3
+
+A VPC Gateway for S3 is not created by default.
+
+Setting the argument "create_vpcep_s3" to "true" will create a VPC Gateway.
+
+Setting "create_vpcep_s3" to "true" will create the following:
+
+* VPC Gateway for S3 w/ policy
+* A route in the public and private route table pointing to the VPC Gateway for S3
+
+```hcl
+module "network" {
+  source      = "git::https://github.com/zoitech/terraform-aws-network.git"
+  vpc_name    = "my_vpc"
+  vpc_network = "10.161.32.0/21"
+  region      = "eu-central-1"
+  create_vpcep_s3 = true
+}
+```
 
 ### To Reference A Tagged Version of the Repository
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## 2.2.5
+
+ENHANCEMENTS:
+
+* Add optional creation of VPC Gateway for AWS S3
+
 ## 2.2.4
 
 BUG FIXES:

--- a/locals.tf
+++ b/locals.tf
@@ -58,7 +58,7 @@ locals {
   create_vpcep_s3       = (var.create_vpcep_s3 == true ? 1 : 0)
   create_vpcep_dynamodb = (var.create_vpcep_dynamodb == true ? 1 : 0)
 
-  vpcep_s3_tags       = merge({ "Name" = var.vpc_name }, var.vpcep_s3_tags)
-  vpcep_dynamodb_tags = merge({ "Name" = var.vpc_name }, var.vpcep_dynamodb_tags)
+  vpcep_s3_tags       = merge({ "Name" = var.vpcep_s3_name }, var.vpcep_s3_tags)
+  vpcep_dynamodb_tags = merge({ "Name" = var.vpcep_dynamodb_name }, var.vpcep_dynamodb_tags)
 
 }

--- a/locals.tf
+++ b/locals.tf
@@ -43,14 +43,22 @@ locals {
   sn_public_c = (local.enable_dynamic_subnets == false ? 1 : (length(var.public_subnets_c) > 0 ? length(var.public_subnets_c) : 0))
 
   #igw_tags
-  igw_tags = merge( {  "Name" = var.vpc_name }, var.igw_tags) 
+  igw_tags = merge({ "Name" = var.vpc_name }, var.igw_tags)
 
   #nat_gw_tags
-  nat_gw_tags = merge({  "Name" = var.vpc_name }, var.nat_gw_tags) 
+  nat_gw_tags = merge({ "Name" = var.vpc_name }, var.nat_gw_tags)
 
   # Route table tags
-  rt_private_name = "Private Route" 
+  rt_private_name = "Private Route"
   rt_public_name  = "Public Route"
-  rt_private_tags = merge({ "Name" = local.rt_private_name }, var.rt_private_tags)  
-  rt_public_tags = merge({ "Name" = local.rt_public_name }, var.rt_public_tags) 
+  rt_private_tags = merge({ "Name" = local.rt_private_name }, var.rt_private_tags)
+  rt_public_tags  = merge({ "Name" = local.rt_public_name }, var.rt_public_tags)
+
+  # VPC Endpoints
+  create_vpcep_s3       = (var.create_vpcep_s3 == true ? 1 : 0)
+  create_vpcep_dynamodb = (var.create_vpcep_dynamodb == true ? 1 : 0)
+
+  vpcep_s3_tags       = merge({ "Name" = var.vpc_name }, var.vpcep_s3_tags)
+  vpcep_dynamodb_tags = merge({ "Name" = var.vpc_name }, var.vpcep_dynamodb_tags)
+
 }

--- a/locals.tf
+++ b/locals.tf
@@ -55,10 +55,7 @@ locals {
   rt_public_tags  = merge({ "Name" = local.rt_public_name }, var.rt_public_tags)
 
   # VPC Endpoints
-  create_vpcep_s3       = (var.create_vpcep_s3 == true ? 1 : 0)
-  create_vpcep_dynamodb = (var.create_vpcep_dynamodb == true ? 1 : 0)
-
-  vpcep_s3_tags       = merge({ "Name" = var.vpcep_s3_name }, var.vpcep_s3_tags)
-  vpcep_dynamodb_tags = merge({ "Name" = var.vpcep_dynamodb_name }, var.vpcep_dynamodb_tags)
+  create_vpcep_s3 = (var.create_vpcep_s3 == true ? 1 : 0)
+  vpcep_s3_tags   = merge({ "Name" = var.vpcep_s3_name }, var.vpcep_s3_tags)
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -331,3 +331,13 @@ variable "vpcep_dynamodb_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "vpcep_s3_name" {
+  description = "The name of the S3 endpoint."
+  default     = "S3 access"
+}
+
+variable "vpcep_dynamodb_name" {
+  description = "The name of the DynamoDB endpoint."
+  default     = "DynamoDB access"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -315,18 +315,7 @@ variable "create_vpcep_s3" {
   default     = false
 }
 
-variable "create_vpcep_dynamodb" {
-  description = "Create VPC endpoint for DynamoDB if set to true"
-  default     = false
-}
-
 variable "vpcep_s3_tags" {
-  description = "Map containing key value tag pairs"
-  type        = map(string)
-  default     = {}
-}
-
-variable "vpcep_dynamodb_tags" {
   description = "Map containing key value tag pairs"
   type        = map(string)
   default     = {}
@@ -335,9 +324,4 @@ variable "vpcep_dynamodb_tags" {
 variable "vpcep_s3_name" {
   description = "The name of the S3 endpoint."
   default     = "S3 access"
-}
-
-variable "vpcep_dynamodb_name" {
-  description = "The name of the DynamoDB endpoint."
-  default     = "DynamoDB access"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -307,3 +307,27 @@ variable "rt_public_tags" {
   type        = map(string)
   default     = {}
 }
+
+# VPC Endpoints
+
+variable "create_vpcep_s3" {
+  description = "Create VPC endpoint for S3 if set to true"
+  default     = false
+}
+
+variable "create_vpcep_dynamodb" {
+  description = "Create VPC endpoint for DynamoDB if set to true"
+  default     = false
+}
+
+variable "vpcep_s3_tags" {
+  description = "Map containing key value tag pairs"
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpcep_dynamodb_tags" {
+  description = "Map containing key value tag pairs"
+  type        = map(string)
+  default     = {}
+}

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -23,25 +23,14 @@ POLICY
   tags         = local.vpcep_s3_tags
 }
 
-resource "aws_vpc_endpoint" "dynamodb" {
-  count  = local.create_vpcep_dynamodb
-  vpc_id = aws_vpc.main.id
+# Route Table Associations
 
-  service_name = "com.amazonaws.${var.region}.s3"
-  policy       = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Id": "Policy1568307208199",
-    "Statement": [
-        {
-            "Sid": "Stmt1568307206805",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": "dynamodb:*",
-            "Resource": "*"
-        }
-    ]
+resource "aws_vpc_endpoint_route_table_association" "s3_public_rt" {
+  route_table_id  = aws_route_table.rt_public.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }
-POLICY
-  tags         = local.vpcep_dynamodb_tags
+
+resource "aws_vpc_endpoint_route_table_association" "s3_private_rt" {
+  route_table_id  = aws_route_table.rt_private.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -1,10 +1,26 @@
+# Endpoints
+
 resource "aws_vpc_endpoint" "s3" {
   count  = local.create_vpcep_s3
   vpc_id = aws_vpc.main.id
 
   service_name = "com.amazonaws.${var.region}.s3"
-
-  tags = local.vpcep_s3_tags
+  policy       = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "Policy1568307208199",
+    "Statement": [
+        {
+            "Sid": "Stmt1568307206805",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
+  tags         = local.vpcep_s3_tags
 }
 
 resource "aws_vpc_endpoint" "dynamodb" {
@@ -12,6 +28,20 @@ resource "aws_vpc_endpoint" "dynamodb" {
   vpc_id = aws_vpc.main.id
 
   service_name = "com.amazonaws.${var.region}.s3"
-
-  tags = local.vpcep_dynamodb_tags
+  policy       = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "Policy1568307208199",
+    "Statement": [
+        {
+            "Sid": "Stmt1568307206805",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "dynamodb:*",
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
+  tags         = local.vpcep_dynamodb_tags
 }

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -1,0 +1,17 @@
+resource "aws_vpc_endpoint" "s3" {
+  count  = local.create_vpcep_s3
+  vpc_id = aws_vpc.main.id
+
+  service_name = "com.amazonaws.${var.region}.s3"
+
+  tags = local.vpcep_s3_tags
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  count  = local.create_vpcep_dynamodb
+  vpc_id = aws_vpc.main.id
+
+  service_name = "com.amazonaws.${var.region}.s3"
+
+  tags = local.vpcep_dynamodb_tags
+}

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -23,14 +23,3 @@ POLICY
   tags         = local.vpcep_s3_tags
 }
 
-# Route Table Associations
-
-resource "aws_vpc_endpoint_route_table_association" "s3_public_rt" {
-  route_table_id  = aws_route_table.rt_public.id
-  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
-}
-
-resource "aws_vpc_endpoint_route_table_association" "s3_private_rt" {
-  route_table_id  = aws_route_table.rt_private.id
-  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
-}

--- a/vpc_internet_gateway.tf
+++ b/vpc_internet_gateway.tf
@@ -3,6 +3,6 @@ resource "aws_internet_gateway" "igw" {
   count  = local.create_igw
   vpc_id = aws_vpc.main.id
 
-  tags =  local.igw_tags
+  tags = local.igw_tags
 
 }

--- a/vpc_nat_gateway.tf
+++ b/vpc_nat_gateway.tf
@@ -4,10 +4,10 @@ resource "aws_eip" "natgw_eip" {
 }
 
 resource "aws_nat_gateway" "natgw" {
-  count         = local.create_nat 
+  count         = local.create_nat
   allocation_id = aws_eip.natgw_eip.0.id
-  subnet_id = local.vpc_nat_gateway_subnet_id
-  depends_on = [aws_internet_gateway.igw]
+  subnet_id     = local.vpc_nat_gateway_subnet_id
+  depends_on    = [aws_internet_gateway.igw]
 
-  tags =  local.nat_gw_tags 
+  tags = local.nat_gw_tags
 }

--- a/vpc_route_tables.tf
+++ b/vpc_route_tables.tf
@@ -2,13 +2,13 @@
 resource "aws_route_table" "rt_public" {
   vpc_id = aws_vpc.main.id
 
-  tags =  local.rt_public_tags
+  tags = local.rt_public_tags
 }
 
 resource "aws_route_table" "rt_private" {
   vpc_id = aws_vpc.main.id
 
-  tags =  local.rt_private_tags
+  tags = local.rt_private_tags
 }
 
 # route table associations

--- a/vpc_route_tables.tf
+++ b/vpc_route_tables.tf
@@ -48,6 +48,20 @@ resource "aws_route_table_association" "rt_private_c" {
   route_table_id = aws_route_table.rt_private.id
 }
 
+
+## VPC Endpoint
+
+resource "aws_vpc_endpoint_route_table_association" "s3_public_rt" {
+  route_table_id  = aws_route_table.rt_public.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3_private_rt" {
+  route_table_id  = aws_route_table.rt_private.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+}
+
+
 # routes
 resource "aws_route" "rt_public_default" {
   count                  = local.create_igw

--- a/vpc_route_tables.tf
+++ b/vpc_route_tables.tf
@@ -52,11 +52,13 @@ resource "aws_route_table_association" "rt_private_c" {
 ## VPC Endpoint
 
 resource "aws_vpc_endpoint_route_table_association" "s3_public_rt" {
+  count           = local.create_vpcep_s3
   route_table_id  = aws_route_table.rt_public.id
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }
 
 resource "aws_vpc_endpoint_route_table_association" "s3_private_rt" {
+  count           = local.create_vpcep_s3
   route_table_id  = aws_route_table.rt_private.id
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }


### PR DESCRIPTION
enhancement of #42 

Current limitation:
1. VPC gateway endpoint needs to specify the service (S3, DynamoDB...)
2. VPC gateway endpoint needs a route table amendment to work

While you can have multimple VPC gateway endpoints, you can only have one route table amendment. That means, you need to pick which service is available via routing to you - the other service will remain unreachable.

We decided to implement S3, as this is currently needed the most.