### PR TITLE
#46: Add support for transit gateway attachments when AZ has multiple subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ For the transit gateway attachment to be successful:
 4. In the "child" account: Run and apply the terraform code referencing this module.
 5. In the account with the transit gateway: The request to attach the transit gateway to the VPC from the "child" account needs to be accepted within the transit gateway resource (unless auto accept is activated).
 
+### Transit Gateway Attachment and multiple subnets
+
+If a giving VPC has multiple subnets within the same availabilty zone, you need to specify which subnet should be used as the transit gateway attachment. 
+
+By default, the module uses the first subnet of each availability zone as the transit gateway attachemnt. Optionally, it is possible to specify a different subnet 
+by using the **tgw_attachment_aza_subnet**, **tgw_attachment_azb_subnet**, and **tgw_attachment_azc_subnet** variables. 
+
+The value of tgw_attachment_aza_subnet, tgw_attachment_azb_subnet, and tgw_attachment_azc_subnet is the index of the subnet to be attached to the transit gateway, 
+within the list of subnets in *private_subnets_a*, *private_subnets_b*, and *private_subnets_c*.
+
 ### VPC Gateway for S3
 
 A VPC Gateway for S3 is not created by default.

--- a/locals.tf
+++ b/locals.tf
@@ -43,6 +43,12 @@ locals {
   sn_public_b = (local.enable_dynamic_subnets == false ? 1 : (length(var.public_subnets_b) > 0 ? length(var.public_subnets_b) : 0))
   sn_public_c = (local.enable_dynamic_subnets == false ? 1 : (length(var.public_subnets_c) > 0 ? length(var.public_subnets_c) : 0))
 
+  # Private subnet to be attached to TGW.
+  private_a_tgw_attachment = local.sn_private_a > 0 ? (var.tgw_attachment_aza_subnet >= 0 ? aws_subnet.sn_private_a[var.tgw_attachment_aza_subnet].id : aws_subnet.sn_private_a[0].id) : ""
+  private_b_tgw_attachment = local.sn_private_b > 0 ? (var.tgw_attachment_azb_subnet >= 0 ? aws_subnet.sn_private_b[var.tgw_attachment_azb_subnet].id : aws_subnet.sn_private_b[0].id) : ""
+  private_c_tgw_attachment = local.sn_private_c > 0 ? (var.tgw_attachment_azc_subnet >= 0 ? aws_subnet.sn_private_c[var.tgw_attachment_azc_subnet].id : aws_subnet.sn_private_c[0].id) : ""
+  subnet_ids               = flatten([local.private_a_tgw_attachment, local.private_b_tgw_attachment, local.private_c_tgw_attachment])
+
   #igw_tags
   igw_tags = merge({ "Name" = var.vpc_name }, var.igw_tags)
 
@@ -63,9 +69,10 @@ locals {
   vpcep_dynamodb_tags   = merge({ "Name" = var.vpcep_dynamodb_name }, var.vpcep_dynamodb_tags)
 
   # Enable dynamic AZs
-  enable_dynamic_az1 =  (length(var.az1) > 0 ? true : false)
-  enable_dynamic_az2 =  (length(var.az2) > 0 ? true : false)
-  enable_dynamic_az3 =  (length(var.az3) > 0 ? true : false)
+  enable_dynamic_az1 = (length(var.az1) > 0 ? true : false)
+  enable_dynamic_az2 = (length(var.az2) > 0 ? true : false)
+  enable_dynamic_az3 = (length(var.az3) > 0 ? true : false)
+
   # Availability Zones
   az1 = (local.enable_dynamic_az1 == false ? "${var.region}a" : var.az1)
   az2 = (local.enable_dynamic_az2 == false ? "${var.region}b" : var.az2)

--- a/variables.tf
+++ b/variables.tf
@@ -86,18 +86,18 @@ variable "dhcp_domain_name" {
 }
 
 variable "domain_name_servers" {
-  type    = list
+  type    = list(any)
   default = []
 
 }
 
 variable "ntp_servers" {
-  type    = list
+  type    = list(any)
   default = []
 }
 
 variable "netbios_name_servers" {
-  type    = list
+  type    = list(any)
   default = []
 }
 
@@ -188,6 +188,21 @@ variable "share_arn" {
 
 variable "create_tgw_attachment" {
   default = false
+}
+
+variable "tgw_attachment_aza_subnet" {
+  description = "The private subnet in the availability zone A to be attached to the Transit Gateway"
+  default     = -1
+}
+
+variable "tgw_attachment_azb_subnet" {
+  description = "The private subnet in the availability zone B to be attached to the Transit Gateway"
+  default     = -1
+}
+
+variable "tgw_attachment_azc_subnet" {
+  description = "The private subnet in the availability zone C to be attached to the Transit Gateway"
+  default     = -1
 }
 
 variable "create_tgw_attachment_without_ram" {

--- a/vpc_transit_gateway_attachment.tf
+++ b/vpc_transit_gateway_attachment.tf
@@ -4,8 +4,9 @@ resource "aws_ram_resource_share_accepter" "network_transit_gateway" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "network_transit_gateway" {
-  count              = local.create_tgw_attachment
-  subnet_ids         = flatten([aws_subnet.sn_private_a[*].id, aws_subnet.sn_private_b[*].id, aws_subnet.sn_private_c[*].id])
+  count = local.create_tgw_attachment
+  # subnet_ids         = flatten([aws_subnet.sn_private_a[*].id, aws_subnet.sn_private_b[*].id, aws_subnet.sn_private_c[*].id])
+  subnet_ids         = local.subnet_ids
   transit_gateway_id = var.transit_gateway_id
   vpc_id             = aws_vpc.main.id
 
@@ -19,8 +20,9 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "network_transit_gateway" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "network_transit_gateway_without_ram" {
-  count              = local.create_tgw_attachment_without_ram
-  subnet_ids         = flatten([aws_subnet.sn_private_a[*].id, aws_subnet.sn_private_b[*].id, aws_subnet.sn_private_c[*].id])
+  count = local.create_tgw_attachment_without_ram
+  # subnet_ids        = flatten([aws_subnet.sn_private_a[*].id, aws_subnet.sn_private_b[*].id, aws_subnet.sn_private_c[*].id])
+  subnet_ids         = local.subnet_ids
   transit_gateway_id = var.transit_gateway_id
   vpc_id             = aws_vpc.main.id
 


### PR DESCRIPTION
## Description:
With this PR, the module will supports transit gateway attachments when availability zones (AZ) have more than one subnet.

In summary, this PR will add new variables to the module so that one can specify which subnet of each AZ should be used in the transit gateway attachment.

If the variables aren't used, the module will take the first private subnet in each AZ as the subnet to be used in the transit gateway attachment.

### Type of change
<!--
  Please select what is the type of change implemented by this merge request
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?
<!--
  Indicate if this merge request was tested and how it was tested. 
  If you deployed changes manually to servers, provide the instance name(s), screenshots, logs, or any other relevant information to show that tests have been performed successfully.
-->
Changes implemented by this PR have been successfully tested locally in a non-productive environment.

## Relation:
Resolves #46