### PR TITLE
Fix transit gateway attachments

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -44,9 +44,9 @@ locals {
   sn_public_c = (local.enable_dynamic_subnets == false ? 1 : (length(var.public_subnets_c) > 0 ? length(var.public_subnets_c) : 0))
 
   # Private subnet to be attached to TGW.
-  private_a_tgw_attachment = local.sn_private_a > 0 ? (var.tgw_attachment_aza_subnet >= 0 ? aws_subnet.sn_private_a[var.tgw_attachment_aza_subnet].id : aws_subnet.sn_private_a[0].id) : ""
-  private_b_tgw_attachment = local.sn_private_b > 0 ? (var.tgw_attachment_azb_subnet >= 0 ? aws_subnet.sn_private_b[var.tgw_attachment_azb_subnet].id : aws_subnet.sn_private_b[0].id) : ""
-  private_c_tgw_attachment = local.sn_private_c > 0 ? (var.tgw_attachment_azc_subnet >= 0 ? aws_subnet.sn_private_c[var.tgw_attachment_azc_subnet].id : aws_subnet.sn_private_c[0].id) : ""
+  private_a_tgw_attachment = local.sn_private_a > 0 ? tolist([(var.tgw_attachment_aza_subnet >= 0 ? aws_subnet.sn_private_a[var.tgw_attachment_aza_subnet].id : aws_subnet.sn_private_a[0].id)]) : []
+  private_b_tgw_attachment = local.sn_private_b > 0 ? tolist([(var.tgw_attachment_azb_subnet >= 0 ? aws_subnet.sn_private_b[var.tgw_attachment_azb_subnet].id : aws_subnet.sn_private_b[0].id)]) : []
+  private_c_tgw_attachment = local.sn_private_c > 0 ? tolist([(var.tgw_attachment_azc_subnet >= 0 ? aws_subnet.sn_private_c[var.tgw_attachment_azc_subnet].id : aws_subnet.sn_private_c[0].id)]) : []
   subnet_ids               = flatten([local.private_a_tgw_attachment, local.private_b_tgw_attachment, local.private_c_tgw_attachment])
 
   #igw_tags


### PR DESCRIPTION
## Description:
This PR resolves #55, caused when creating a Transit Gateway attachment for an AZ that has no private subnets.

This PR will amend the value of the `locals.tf` file to ensure an empty list is returned when an AZ has no private subnets.

### Type of change
<!--
  Please select what is the type of change implemented by this merge request
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!--
  Indicate if this merge request was tested and how it was tested. 
  If you deployed changes manually to servers, provide the instance name(s), screenshots, logs, or any other relevant information to show that tests have been performed successfully.
-->
Changes implemented by this PR have been successfully tested locally in a non-productive environment.

## Relation:
Resolves #55 